### PR TITLE
Wifi接続に必要なパッケージを追加

### DIFF
--- a/livebuild/config/binary
+++ b/livebuild/config/binary
@@ -1,7 +1,7 @@
 # config/binary - options for live-build(7), binary stage
 
 # Set image type
-LB_IMAGE_TYPE="iso-hybrid"
+LB_IMAGE_TYPE="iso"
 
 # Set image filesystem
 LB_BINARY_FILESYSTEM="fat32"
@@ -53,7 +53,7 @@ LB_BUILD_WITH_CHROOT="true"
 LB_DEBIAN_INSTALLER="none"
 
 # Set debian-installer suite
-LB_DEBIAN_INSTALLER_DISTRIBUTION="bookworm"
+LB_DEBIAN_INSTALLER_DISTRIBUTION="testing"
 
 # Set debian-installer preseed filename/url
 LB_DEBIAN_INSTALLER_PRESEEDFILE=""
@@ -80,7 +80,7 @@ LB_ISO_PREPARER="live-build @LB_VERSION@; https://salsa.debian.org/live-team/liv
 LB_ISO_PUBLISHER="Debian Live project; https://wiki.debian.org/DebianLive; debian-live@lists.debian.org"
 
 # Set iso volume (max 32 chars)
-LB_ISO_VOLUME="bookworm-live-image"
+LB_ISO_VOLUME="Debian testing @ISOVOLUME_TS@"
 
 # Set jffs2 eraseblock size
 LB_JFFS2_ERASEBLOCK=""

--- a/livebuild/config/bootstrap
+++ b/livebuild/config/bootstrap
@@ -10,16 +10,16 @@ LB_DISTRIBUTION="testing"
 LB_PARENT_DISTRIBUTION="testing"
 
 # Select distribution to use in the chroot
-LB_DISTRIBUTION_CHROOT="bookworm"
+LB_DISTRIBUTION_CHROOT="testing"
 
 # Select parent distribution to use in the chroot
-LB_PARENT_DISTRIBUTION_CHROOT="bookworm"
+LB_PARENT_DISTRIBUTION_CHROOT="testing"
 
 # Select distribution to use in the final image
-LB_DISTRIBUTION_BINARY="bookworm"
+LB_DISTRIBUTION_BINARY="testing"
 
 # Select parent distribution to use in the final image
-LB_PARENT_DISTRIBUTION_BINARY="bookworm"
+LB_PARENT_DISTRIBUTION_BINARY="testing"
 
 # Select parent distribution for debian-installer to use
 LB_PARENT_DEBIAN_INSTALLER_DISTRIBUTION="testing"

--- a/livebuild/config/common
+++ b/livebuild/config/common
@@ -13,7 +13,7 @@ LB_APT_HTTP_PROXY=""
 LB_APT_PIPELINE=""
 
 # Set apt/aptitude recommends
-LB_APT_RECOMMENDS="true"
+LB_APT_RECOMMENDS="false"
 
 # Set apt/aptitude security
 LB_APT_SECURE="true"
@@ -55,7 +55,7 @@ LB_MODE="debian"
 LB_SYSTEM="live"
 
 # Set base name of the image
-LB_IMAGE_NAME="PLDE_alpha1_20230428"
+LB_IMAGE_NAME="PLDE_alpha1_20230429"
 
 # Set options to use with apt
 APT_OPTIONS="--yes -o Acquire::Retries=5"

--- a/livebuild/config/package-lists/desktop.list.chroot
+++ b/livebuild/config/package-lists/desktop.list.chroot
@@ -26,3 +26,5 @@ autofs
 pulseaudio
 pavucontrol
 
+wpasupplicant
+

--- a/livebuild/prep.sh
+++ b/livebuild/prep.sh
@@ -6,6 +6,7 @@ IMAGE_NAME="PLDE_alpha1_${TIMESTAMP}"
 lb config \
 	--apt apt \
 	--architecture amd64 \
+	--apt-recommends false \
 	--distribution testing  \
 	--parent-distribution testing \
 	--parent-debian-installer-distribution testing \
@@ -14,5 +15,6 @@ lb config \
 	--mirror-chroot "http://ftp.riken.go.jp/Linux/debian/debian" \
 	--mirror-binary "http://ftp.riken.go.jp/Linux/debian/debian" \
 	--bootappend-live "boot=live components locales=ja_JP.UTF-8 debug=1" \
-	--image-name ${IMAGE_NAME}
+	--binary-image iso \
+	--image-name ${IMAGE_NAME} 
 


### PR DESCRIPTION
issue #5 に対応するため，`wpasupplicant`を追加した．
また，あわせて以下の変更を適用．
- binary image typeを`iso-hybrid`から`iso`に変更
- apt-recommendsパッケージのインストール設定を`false`に変更