### PR TITLE
 インストール後のapt sourceがbookwormに戻っている #13 の修正

### DIFF
--- a/resources/rootfs/etc/apt/sources.list
+++ b/resources/rootfs/etc/apt/sources.list
@@ -1,0 +1,8 @@
+deb http://deb.debian.org/debian/ testing main
+deb-src http://deb.debian.org/debian/ testing main
+
+deb http://security.debian.org/debian-security testing-security main
+deb-src http://security.debian.org/debian-security testing-security main
+
+deb http://deb.debian.org/debian/ testing-updates main
+deb-src http://deb.debian.org/debian/ testing-updates main


### PR DESCRIPTION
 resourcesのrootfs以下に/etc/apt/sources.listを追加