### PR TITLE
 インストール後のapt sourceがbookwormに戻っている #13 の修正２

### DIFF
--- a/resources/rootfs/etc/apt/sources.list.testing
+++ b/resources/rootfs/etc/apt/sources.list.testing
@@ -1,0 +1,13 @@
+# See https://wiki.debian.org/SourcesList for more information.
+deb http://deb.debian.org/debian testing main non-free-firmware
+deb-src http://deb.debian.org/debian testing main non-free-firmware
+
+deb http://deb.debian.org/debian testing-updates main non-free-firmware
+deb-src http://deb.debian.org/debian testing-updates main non-free-firmware
+
+deb http://security.debian.org/debian-security/ testing-security main non-free-firmware
+deb-src http://security.debian.org/debian-security/ testing-security main non-free-firmware
+
+# Backports allow you to install newer versions of software made available for this release
+deb http://deb.debian.org/debian testing-backports main non-free-firmware
+deb-src http://deb.debian.org/debian testing-backports main non-free-firmware

--- a/resources/rootfs/etc/systemd/system/chg_aptlist.service
+++ b/resources/rootfs/etc/systemd/system/chg_aptlist.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=cheng apt sources.list
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/chg_aptlist
+
+[Install]
+WantedBy=graphical.target

--- a/resources/rootfs/etc/systemd/system/graphical.target.wants/chg_aptlist.service
+++ b/resources/rootfs/etc/systemd/system/graphical.target.wants/chg_aptlist.service
@@ -1,0 +1,1 @@
+../chg_aptlist.service

--- a/resources/rootfs/usr/sbin/chg_aptlist
+++ b/resources/rootfs/usr/sbin/chg_aptlist
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+TESTING_FILE="/etc/apt/sources.list.testing"
+LIST_FILE="/etc/apt/sources.list"
+BKUP_FILE="/etc/apt/sources.list-bkup"$$
+
+if [ $TESTING_FILE -ot $LIST_FILE ]
+then
+    cp -fp $LIST_FILE $BKUP_FILE
+    cp -fp $TESTING_FILE $LIST_FILE
+fi


### PR DESCRIPTION
systemd でenable disable対応しました。
サービス名はchg_aptlist.serviceeです。
作成したISOファイルでインストールし、実行確認しています。
