### PR TITLE
xfdesktopの起動を待って壁紙設定

### DIFF
--- a/resources/rootfs/usr/share/plasmalinux/plasmalinux_backgrounds.sh
+++ b/resources/rootfs/usr/share/plasmalinux/plasmalinux_backgrounds.sh
@@ -4,7 +4,18 @@ DEFAULT_BACKGROUNDS=/usr/share/backgrounds/plasma_dark.png
 RUNFILE_DIR=~/.config/plasmalinux
 RUNFILE="$RUNFILE_DIR"/.plasmalinux_backgrounds.run
 
-sleep 1
+#wait for xfdesktop to start
+if [ `echo $USER` = "plasma" ];then
+    TIME=5
+else
+    TIME=1
+fi
+
+sleep $TIME
+until ps -C xfdesktop > /dev/null; do
+    sleep $TIME
+done
+
 
 # exit if the script has been run before
 [[ -f $RUNFILE ]] && exit 0


### PR DESCRIPTION
実機で壁紙の変更ができない場合があったため、xfdesktopの起動を待って設定をするように変更。
また、LIVE環境で壁紙の変更ができない場合があったため、LIVE環境の場合に待機時間を長くした。